### PR TITLE
PSEC-1472 minor fixups

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,3 +4,4 @@ ignore:
   sha: []
 merge-message-formats: {}
 next-version: 0.1.0
+increment: Minor # temporary - Remove or set to Patch when version 1.0.0 reached

--- a/README.md
+++ b/README.md
@@ -1,36 +1,37 @@
 # S3 bucket core module
 
-This module enforces some of the PlatSec S3 bucket policy. As the bucket and kms key policies are provided, the user of
-this module will be responsible for ensuring the bucket created with this module complies with the policy.
+This module enforces some of the MDTP PlatSec S3 bucket policy. As the bucket and kms key policies need to be provided,
+the user of this module will be responsible for ensuring the bucket created with this module complies with the policy.
 
-There is a "standard" bucket module that will comply with the policy while also requiring that no S3 permissions need
-to be managed.
+There is a [standard bucket module](https://registry.terraform.io/modules/hmrc/s3-bucket-standard/aws/latest) that will
+comply with the policy while also requiring that no S3 permissions need to be managed.
 
 
 ## Policy enforcement
 
-#### Logging
-**S3 Server Access logging is enabled.** The target bucket must be supplied with variable `log_bucket_id`
+### Logging
+**S3 server access logging is enabled.** The target bucket must be supplied with variable `log_bucket_id`. The logs for
+this bucket will be stored with the prefix <account_id>/<bucket_name>
 
-#### Bucket policy
+### Bucket policy
 
 **Public access is blocked.**
 
-#### Tagging
+### Tagging
 
 **`data_sensitivity` tag will be set to either "high" or "low".** Set with the variable `data_sensitivity` (default
 "low"). For buckets with PII or other sensitive data, the tag **must** be "high".
 
 **`data_expiry` tag will be added - see Life cycle policies below.**
 
-#### Versioning
+### Versioning
 
 In order to ensure that data is not accidentally lost, versioning **should** be enabled. Versioning is controlled by
 the variable `versioning_enabled` which defaults to `true`.
 
 **Version expiration is enabled for non-current entries and is set to 90 days.**
 
-#### Life cycle policies
+### Life cycle policies
 
 One of the following data_expiry values must be chosen. The bucket tag `data_expiry` will be set to the value chosen
 and a lifecycle rule added to ensure data expires after the appropriate number of days.
@@ -46,14 +47,14 @@ and a lifecycle rule added to ensure data expires after the appropriate number o
 | 7-years    | 2557 days  |
 | 10-years   | 3653 days  |
 
-#### Encryption at rest
+### Encryption at rest, Key management service
 
 The bucket will be encrypted with a KMS key created by this module, but the KMS policy must be supplied with the
 `kms_key_policy` variable (sting of JSON).
 
 **KMS key rotation is enabled.**
 
-#### Access control list (ACL)
+### Access control list (ACL)
 
 Bucket ownership controls are set to `BucketOwnerEnforced` which means that bucket ACLs have no effect (equivalent to
 the default "private")

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 module "bucket" {
-  #source      = "hashicorp/hmrc/s3-bucket-core"
+  #source      = "hmrc/s3-bucket-core/aws"
   source      = "../../"
   bucket_name = local.bucket_name
 

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ locals {
 
 }
 
-resource "aws_s3_bucket" "s3_bucket" {
+resource "aws_s3_bucket" "bucket" {
   bucket = var.bucket_name
   acl    = "private"
 
@@ -76,16 +76,16 @@ resource "aws_s3_bucket" "s3_bucket" {
   }
 }
 
-resource "aws_s3_bucket_ownership_controls" "example" {
-  bucket = aws_s3_bucket.s3_bucket.id
+resource "aws_s3_bucket_ownership_controls" "bucket_owner_enforced" {
+  bucket = aws_s3_bucket.bucket.id
 
   rule {
     object_ownership = "BucketOwnerEnforced"
   }
 }
 
-resource "aws_s3_bucket_public_access_block" "public_access_block" {
-  bucket                  = aws_s3_bucket.s3_bucket.id
+resource "aws_s3_bucket_public_access_block" "public_blocked" {
+  bucket                  = aws_s3_bucket.bucket.id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,15 @@
 output "id" {
   description = "The name of the bucket"
-  value       = aws_s3_bucket.s3_bucket.id
+  value       = aws_s3_bucket.bucket.id
 }
 
 output "arn" {
   description = "The ARN of the bucket"
-  value       = aws_s3_bucket.s3_bucket.arn
+  value       = aws_s3_bucket.bucket.arn
 }
 
 output "bucket_regional_domain_name" {
-  value = aws_s3_bucket.s3_bucket.bucket_regional_domain_name
+  value = aws_s3_bucket.bucket.bucket_regional_domain_name
 }
 
 output "kms_alias_arn" {

--- a/test/s3_module_acceptance_test.go
+++ b/test/s3_module_acceptance_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
@@ -109,20 +108,12 @@ func copyTerraformAndReturnOptions(t *testing.T, pathFromRootToSource string, ad
 	for k, v := range additionalVars {
 		vars[k] = v
 	}
-	return CopyTerraformAndReturnOptions(t, pathFromRootToSource, "hashicorp/hmrc/s3-bucket-core", vars)
+	return CopyTerraformAndReturnOptions(t, pathFromRootToSource, vars)
 }
 
-func CopyTerraformAndReturnOptions(t *testing.T, pathFromRootToSource string, publicModuleSrc string, vars map[string]interface{}) *terraform.Options {
+func CopyTerraformAndReturnOptions(t *testing.T, pathFromRootToSource string, vars map[string]interface{}) *terraform.Options {
 	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "..", pathFromRootToSource)
 	log.Print(tempTestFolder)
-
-	publicToLocalModuleExp := `/^module \.*/,/^\}\s*$/ s#\(source\s*=\s*\)"` + publicModuleSrc + `"#\1"../../"#`
-	useLocalModule := shell.Command{
-		Command:    "sed",
-		Args:       []string{"-i", "-e", publicToLocalModuleExp, "main.tf"},
-		WorkingDir: tempTestFolder,
-	}
-	shell.RunCommand(t, useLocalModule)
 
 	return terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: tempTestFolder,


### PR DESCRIPTION
increase size of policy section headings
change link to std module from GitHub to TF registry
remove code to fixup registry module source reference to local
fixup resource names as they are exposed in the registry UI
bump minor version part for each build while we are not production
ready (<1.0.0)
