### PR TITLE
Remove "low" default for `data_sensitivity`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -22,8 +22,7 @@ variable "force_destroy" {
 
 variable "data_sensitivity" {
   type        = string
-  description = "Defaults to low. For buckets with PII or other sensitive data, the tag data_sensitivity: high must be applied."
-  default     = "low"
+  description = "For buckets with PII or other sensitive data, the tag data_sensitivity: high must be applied."
 
   validation {
     condition     = var.data_sensitivity == "high" || var.data_sensitivity == "low"


### PR DESCRIPTION
We want users to have to make a decision on this input. Defaulting to low could result in users not being aware they had to set this var