### PR TITLE
TRG-1171: Permit (but do not recommend) the ability to override the default bucket ownership setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ By default this var is set to 'False' and a KMS key is created. A KMS policy mus
 
 ### Access control list (ACL)
 
-Bucket ownership controls are set to `BucketOwnerEnforced` which means that bucket ACLs have no effect (equivalent to
-the default "private")
+Bucket ownership controls are set to `BucketOwnerEnforced` by default, which means that bucket ACLs have no effect (equivalent to
+the default "private"). This can be overridden if necessary to facilitate certain behaviours, such as allowing CloudFront to deliver standard logs to the bucket,
+but the default should be used whenever possible as it offers the best security position.
 
 ### Object Lock
 

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "aws_s3_bucket_ownership_controls" "bucket_owner_enforced" {
   bucket = aws_s3_bucket.bucket.id
 
   rule {
-    object_ownership = "BucketOwnerEnforced"
+    object_ownership = var.bucket_object_ownership
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "bucket_name" {
   description = "The name of the S3 bucket to create"
 }
 
+variable "bucket_object_ownership" {
+  type        = string
+  description = "The setting used to define ownership of bucket objects. Defaults to 'BucketOwnerEnforced', which is the recommended setting. Can be changed in situations where less secure settings are required e.g. to allow CloudFront to deliver standard logs to the bucket, which requires 'BucketOwnerPreferred'."
+  default     = "BucketOwnerEnforced"
+}
+
 variable "versioning_enabled" {
   type        = bool
   description = "When true the s3 bucket contents will be versioned"


### PR DESCRIPTION
This allows the module to support use-cases which require a more permissive object ownership setting, such as the delivery of CloudFront standard access logs.
