### PR TITLE
PSEC-2237 Adding tags to kms resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,8 @@ resource "aws_kms_key" "bucket_kms_key" {
   description         = "KMS key used to encrypt files for ${var.bucket_name}"
   enable_key_rotation = true
   policy              = var.kms_key_policy
+
+  tags = var.tags
 }
 
 resource "aws_kms_alias" "bucket_kms_alias" {


### PR DESCRIPTION
Allowing tags to be passed by the user to the aws_kms_key resource.